### PR TITLE
Add Superhighway to Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Autonomous and semi-autonomous agents that plan, search, and synthesize.
 - [Lune](https://luneresearch.com) - MCP server giving agents grounded knowledge and tools for scientific workflows, sourced from research papers.
 - [PaperQA2](https://github.com/Future-House/paper-qa) - Open-source RAG agent for high-accuracy Q&A over scientific PDFs with grounded citations.
 - [Stanford STORM](https://github.com/stanford-oval/storm) - LLM knowledge-curation system that researches a topic and writes a Wikipedia-style report with citations.
+- [Superhighway](https://superhighway.walls.sh) - Web search API for AI agents (search, news, scrape, research) with a [guide for building an academic literature-review agent](https://superhighway.walls.sh/guides/academic-research-agent) in Python; pay-per-call with USDC or a free API key.
 
 <a id="reading--paper-qa"></a>
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh), a web search API for AI agents (search, news, scrape, research), to the **Research Agents** section.

It's particularly relevant here because of its [step-by-step guide for building an academic literature-review agent](https://superhighway.walls.sh/guides/academic-research-agent) in Python — the agent finds papers, scrapes abstracts, synthesizes a topic, and generates a structured literature review with research gaps and a recommended reading order.

Entry is placed alphabetically in the Research Agents list and follows the existing one-line-description format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)