### PR TITLE
Add ALMa to Literature Review & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Search engines, databases, and feeds for finding relevant work.
 
 - [2Dsearch](https://app.2dsearch.com/) - Visual canvas-based Boolean query builder for systematic search.
 - [Ai2 Asta](https://asta.allen.ai) - Allen AI's agentic ecosystem for scholarly Q&A and evidence-grounded literature synthesis.
+- [ALMa](https://github.com/costantinoai/alma-library-manager) - Self-hosted paper discovery engine that recommends related work, tracks author feeds, and learns from your saves.
 - [ASReview](https://asreview.nl/) - Open-source AI-assisted screening for systematic reviews.
 - [Consensus](https://consensus.app/) - Search engine that extracts consensus answers directly from research papers.
 - [Dimensions](https://www.dimensions.ai/) - Scholarly research analytics database covering 164M+ publications.


### PR DESCRIPTION
Adds **ALMa**, a self-hosted paper discovery engine, to *Literature Review & Discovery*.

I built ALMa to stay on top of my field without living in a dozen browser tabs. It monitors sources (OpenAlex, Semantic Scholar, Crossref), surfaces new papers in a chronological feed, and recommends related and potentially relevant work using SPECTER2 embeddings. It learns from what you save, like, or dismiss, so the recommendations sharpen over time.

Checked against the contributing criteria:
- **Alive** — actively maintained, one-line Docker install, current release v0.21.0.
- **Research-focused** — built specifically for researchers tracking literature; not a general chatbot.
- **Distinct** — the discovery tools already listed (Research Rabbit, R Discovery, Semantic Scholar) are hosted SaaS. ALMa is self-hosted and single-user: your library and reading signals stay on your own machine.

Entry added in alphabetical order (between Ai2 Asta and ASReview); format matches the list; description is 16 words with no marketing language.

Repo: https://github.com/costantinoai/alma-library-manager