### PR TITLE
Add Jacobian to research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Autonomous and semi-autonomous agents that plan, search, and synthesize.
 - [BGPT](https://github.com/connerlambden/bgpt-mcp) - REST/Python and MCP scientific-paper search returning structured full-text evidence: methods, limitations, conflicts of interest, and quality scores.
 - [Edison Kosmos](https://www.edisonscientific.com/) - Multi-agent platform (ex-FutureHouse) running parallel research tasks across literature and datasets.
 - [Iris.ai](https://iris.ai/) - Enterprise agentic RAG platform for ingesting and analyzing scientific documents.
+- [Jacobian](https://github.com/morluto/jacobian) - MCP server and Python library for exact mathematical computation and conjecture testing.
 - [Lune](https://luneresearch.com) - MCP server giving agents grounded knowledge and tools for scientific workflows, sourced from research papers.
 - [PaperQA2](https://github.com/Future-House/paper-qa) - Open-source RAG agent for high-accuracy Q&A over scientific PDFs with grounded citations.
 - [Stanford STORM](https://github.com/stanford-oval/storm) - LLM knowledge-curation system that researches a topic and writes a Wikipedia-style report with citations.


### PR DESCRIPTION
Adds Jacobian to Research Agents, alphabetically between Iris.ai and Lune. One README line added; nothing else touched.

What it is: an MCP server and Python library for exact mathematical computation and conjecture testing.

Why it fits: Jacobian gives research agents a runnable tool for mathematical experiments, with composable operations across polynomial maps, linear algebra, and graph algorithms.

Validation:

- `git diff --check`
- The entry follows the repository's one-line format and stays under the 18-word description limit.