### PR TITLE
Add ThoughtDAG to Notes & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Capture and query research notes, highlights, and team knowledge.
 - [Onyx](https://www.onyx.app/) - Open-source enterprise search and RAG over your team's knowledge (formerly Danswer).
 - [Reflect](https://reflect.app/) - Backlinked notes with AI for outlining, summaries, and voice transcription.
 - [Remio](https://remio.ai/) - Local-first AI knowledge base for querying research files, webpages, recordings, emails, and notes.
+- [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - Local-first research canvas for editing which conversation and document branches enter LLM context.
 
 <a id="resources--trackers"></a>
 


### PR DESCRIPTION
## Project

- **Name:** ThoughtDAG
- **URL:** https://github.com/chenxiachan/thoughtdag
- **Category:** Notes & Knowledge Management

## Research fit

ThoughtDAG is a local-first research canvas for working with branching LLM conversations and source documents. Researchers can inspect and edit which branches enter model context, extract text or images from PDFs into nodes, and preserve alternative reasoning paths.

The added description is factual, under 18 words, and placed alphabetically in the most specific category.

**Disclosure:** I maintain ThoughtDAG.