### PR TITLE
Add ScholarCopilot to writing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Drafting, language polishing, and formatting for academic writing.
 - [Lex](https://lex.page/) - AI-assisted document editor for collaborative writing with grounded suggestions and editing commands.
 - [PaperClaw](https://marketplace.visualstudio.com/items?itemName=agnuxo1.paperclaw) - VS Code extension that drafts IMRaD manuscripts locally via Ollama with Semantic Scholar–cross-referenced citations and LaTeX export.
 - [Prism](https://openai.com/prism/) - Free AI-native LaTeX workspace for scientific writing, collaboration, literature search, and citation support.
+- [ScholarCopilot](https://github.com/TIGER-AI-Lab/ScholarCopilot) - Generates academic prose and retrieves citations through a jointly trained language model.
 - [SciSpace](https://scispace.com/) - AI research assistant for literature review, paper formatting, and writing (formerly Typeset).
 - [Wordvice AI](https://wordvice.ai/) - Grammar, proofread, paraphrase, and summarize tools tuned for academic writing.
 - [Writefull](https://writefull.com/) - Academic writing and editing assistant with Word and Overleaf plugins.


### PR DESCRIPTION
## Summary

Add ScholarCopilot to **Writing & Editing**. The open-source tool jointly completes academic text and retrieves context-relevant papers at learned citation points.

The entry is alphabetized, uses the required factual one-line format in 12 words, and points to the canonical repository. Default-branch plus all-state issue, PR, comment, and review-comment searches found no ScholarCopilot, arXiv 2504.00824, canonical URL, or TIGER-AI-Lab duplicate. `git diff --check` passed.

I am submitting this on behalf of repository maintainer Yuxuan Zhang.