### PR TITLE
Correct the Lune entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Autonomous and semi-autonomous agents that plan, search, and synthesize.
 - [Edison Kosmos](https://www.edisonscientific.com/) - Multi-agent platform (ex-FutureHouse) running parallel research tasks across literature and datasets.
 - [Iris.ai](https://iris.ai/) - Enterprise agentic RAG platform for ingesting and analyzing scientific documents.
 - [Jacobian](https://github.com/morluto/jacobian) - MCP server and Python library for exact mathematical computation and conjecture testing.
-- [Lune](https://luneresearch.com) - MCP server giving agents grounded knowledge and tools for scientific workflows, sourced from research papers.
+- [Lune Research](https://github.com/RetrogradeLabs/lune-mcp-server) - MCP server grounding agents in full-text peer-reviewed papers from top venues (NeurIPS, ICLR, ACL, CVPR, USENIX Security), with citation trails in both directions and claim verification that returns verbatim supporting quotes.
 - [PaperQA2](https://github.com/Future-House/paper-qa) - Open-source RAG agent for high-accuracy Q&A over scientific PDFs with grounded citations.
 - [Stanford STORM](https://github.com/stanford-oval/storm) - LLM knowledge-curation system that researches a topic and writes a Wikipedia-style report with citations.
 


### PR DESCRIPTION
Thanks for including Lune already. Disclosure up front: I work on it, so this is a correction to our own entry rather than a new submission.

Three things the current line gets wrong or leaves out:

1. **It links the marketing site, not the source.** Lune is MIT licensed at https://github.com/RetrogradeLabs/lune-mcp-server. The neighbouring open-source entries (Jacobian, PaperQA2, STORM) all link GitHub, so this is inconsistent as well as less useful.
2. **The name.** `Lune Research` is what `server.json` publishes as the title and what the official MCP Registry shows. It also disambiguates from Lune.dev's unrelated `@lune-inc/mcp`, which currently dominates a "lune mcp" search.
3. **"grounded knowledge and tools for scientific workflows" is vague** and could describe half the section. The specific claims are: the corpus is restricted to peer-reviewed venues so it cannot cite a blog post as a paper, citations are traced in both directions, and a verified claim comes back with the verbatim sentence that supports it.

Alphabetical position is unchanged, still between Jacobian and PaperQA2. One line modified, nothing else.