### PR TITLE
Add OpenPaper to Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Autonomous and semi-autonomous agents that plan, search, and synthesize.
 - [Iris.ai](https://iris.ai/) - Enterprise agentic RAG platform for ingesting and analyzing scientific documents.
 - [Jacobian](https://github.com/morluto/jacobian) - MCP server and Python library for exact mathematical computation and conjecture testing.
 - [Lune](https://luneresearch.com) - MCP server giving agents grounded knowledge and tools for scientific workflows, sourced from research papers.
+- [OpenPaper](https://openpaper.dev/) - Open-source engine where AI agents research a topic and draft a cited paper from real academic sources.
 - [PaperQA2](https://github.com/Future-House/paper-qa) - Open-source RAG agent for high-accuracy Q&A over scientific PDFs with grounded citations.
 - [Stanford STORM](https://github.com/stanford-oval/storm) - LLM knowledge-curation system that researches a topic and writes a Wikipedia-style report with citations.
 


### PR DESCRIPTION
Adding **OpenPaper** (https://openpaper.dev/) under **Research Agents**, placed alphabetically between Lune and PaperQA2.

- **Alive & research-focused:** hosted, actively maintained; open-source engine (OpenDraft, MIT) at https://github.com/federicodeponte/opendraft
- **What it does:** from a single prompt, a multi-agent pipeline runs the literature retrieval and drafts a thesis-level paper with citations verified against real sources (CrossRef, Semantic Scholar, arXiv, OpenAlex, PubMed).
- **Distinct:** unlike STORM (Wikipedia-style reports) or PaperQA2 (Q&A over PDFs), OpenPaper produces a full cited academic draft with export.
- Description is factual and under 18 words, no marketing language.

Thanks for maintaining the list.