### PR TITLE
Add graph2table (chart image to data table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Drafting, language polishing, and formatting for academic writing.
 
 Tools for analyzing research data with AI assistance.
 
+- [graph2table](https://graph2table.com/) - Extracts the data table from a chart image automatically, with a verification overlay and Excel/CSV export.
 - [Hex](https://hex.tech/) - Collaborative agentic notebooks with AI-assisted SQL, Python, and visualization.
 - [Rows](https://rows.com/) - AI-driven spreadsheet that acts as a data analyst for ad-hoc analysis and reporting.
 


### PR DESCRIPTION
Adds graph2table to Data Analysis & Notebooks.

- URL: https://graph2table.com/
- What it does: reads a chart image (from a PDF, a paper, or a screenshot) and returns the data table. The extracted points are drawn on the original image for verification. Exports to Excel and CSV; there is an API.
- Alive: yes, commercial, free to try.
- Distinct from the list: no listed tool extracts numeric data from figures. Mathpix (Transcription & Multimodal) does OCR for tables and math, not chart data.
- Evaluation: state of the art on the ChartX benchmark (77.7 AP@slight vs 30.7 for the best published result), with all extracted tables released: https://graph2table.com/blog/chartx-technical-report

Disclosure: I am the creator of graph2table.
